### PR TITLE
Extend seed logic to use seed_metadata table with hash tracking

### DIFF
--- a/database/migrations/20250723104736_create_seed_metadata.js
+++ b/database/migrations/20250723104736_create_seed_metadata.js
@@ -1,0 +1,25 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function (knex) {
+  const exists = await knex.schema.withSchema('pranesimai').hasTable('seed_metadata');
+  if (!exists) {
+    await knex.schema.withSchema('pranesimai').createTable('seed_metadata', (table) => {
+      table.increments('id').primary();
+      table.string('key').notNullable().unique();
+      table.string('hash').notNullable();
+      table.string('version');
+      table.timestamp('created_at').defaultTo(knex.fn.now());
+      table.timestamp('updated_at').defaultTo(knex.fn.now());
+    });
+  }
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function (knex) {
+  await knex.schema.withSchema('pranesimai').dropTableIfExists('seed_metadata');
+};

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.3"
 
 services:
   postgres:
-    image: postgres:16
+    image: postgres:16.9
     networks:
       - internal
     ports:

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
       "prettier --write",
-      "eslint"
+      "eslint --ignore-pattern dependencies/moleculer-minio/"
     ],
     "*.{md,html,css}": "prettier --write"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2789,9 +2789,8 @@ moleculer-http-client@^0.4.2:
     fastest-validator "^1.12.0"
     lodash "^4.17.21"
 
-"moleculer-minio@github:zeckon/moleculer-minio":
+"moleculer-minio@file:dependencies/moleculer-minio":
   version "2.0.0"
-  resolved "https://codeload.github.com/zeckon/moleculer-minio/tar.gz/d1033162b53143c56cbeb76fa5c55583d554235d"
   dependencies:
     minio "^7.0.21"
     ramda "0.27.1"


### PR DESCRIPTION
This PR extends the seeding mechanism to improve maintainability, traceability, and data integrity by introducing a new metadata-based hash tracking system.

---

## Changes

- **Created `seed_metadata` table** via migration:
  - Stores a hash of the seed templates under a fixed key (e.g. `'surveys.seedHash'`)
  - Used to detect when underlying data (surveys, pages, questions, text) has changed
  - Automatically triggers reseeding if the current hash differs from the stored one
  - Ensures data consistency across environments (local, test, prod)

- **Embedded seed metadata logic directly into `seed.service.ts`**:
  - Uses `broker.call('seed.findOne' | 'create' | 'update')` to manage metadata rows
  - Avoids creating a standalone service for now since metadata is used only internally
  - Keeps seed hash logic co-located with seed execution logic for simplicity

- **Updated logic in `seed.service.ts`**:
  - Hash is generated from seed templates and stored via `seedMetadata`
  - Compares current hash against the stored one on startup
  - Triggers reseeding (with full data wipe + upload) if the hash has changed
  - Ensures up-to-date seed data across all environments

- **Retained optional `version` field**:
  - Available for future schema versioning or migration control
  - Not currently used in comparison logic

- **Added `IS_SEED_REFRESH_ENABLED` feature flag**:
  - Prevents reseeding in `production` and `test` environments by default
  - Allows seed hash comparison and reseeding logic to be safely tested in local/dev only
  - Temporary safeguard until data is fully synced across all environments
---
